### PR TITLE
Remove #[cfg(not(target_os = "linux"))] for recv_mmsg

### DIFF
--- a/src/internal/receiver.rs
+++ b/src/internal/receiver.rs
@@ -17,7 +17,6 @@ use tracing::error;
 /// * `packets`: a mutable array of byte arrays, each of which is the size of
 ///   the largest packet you
 /// want to receive.
-//#[cfg(not(target_os = "linux"))]
 pub async fn recv_mmsg(
     socket: &UdpSocket,
     packets: &mut [[u8; 1280]],

--- a/src/internal/receiver.rs
+++ b/src/internal/receiver.rs
@@ -17,7 +17,7 @@ use tracing::error;
 /// * `packets`: a mutable array of byte arrays, each of which is the size of
 ///   the largest packet you
 /// want to receive.
-#[cfg(not(target_os = "linux"))]
+//#[cfg(not(target_os = "linux"))]
 pub async fn recv_mmsg(
     socket: &UdpSocket,
     packets: &mut [[u8; 1280]],


### PR DESCRIPTION
In this PR, I propose removing the #[cfg(not(target_os = "linux"))] condition for the recv_mmsg function.

This modification will ensure that the recv_mmsg function is available for all platforms, rather than being excluded for non-Linux systems. By removing this conditional compilation, we can streamline the codebase and provide a consistent implementation for all target operating systems.

Will write a separate implementation of the `recv_mmsg` function, utilizing `libc::recv_mmsg` (as described in the [Linux man page](https://linux.die.net/man/2/recvmsg)), to receive multiple packets in a single system call specifically for Linux machines.

This approach can significantly improve the efficiency and performance of packet reception on Linux platforms. By reducing the number of system calls required to receive multiple packets, we can minimize overhead and optimize the code's overall execution.